### PR TITLE
IN 1438 - v1 of tag exporting notebook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,5 @@ ruff-apply: # Resolve 'fixable errors' with 'ruff'
 ####################################
 # Notebook Commands
 ####################################
-edit-notebook:
-	uv run marimo edit --sandbox --headless --no-token notebook.py
-
-run-notebook:
-	uv run marimo run --sandbox --headless --no-token notebook.py
+edit-notebook-tag-export:
+	uv run marimo edit --sandbox --headless --no-token tag_export.py

--- a/README.md
+++ b/README.md
@@ -2,12 +2,28 @@
 
 This repository houses Marimo notebooks that, broadly speaking, work with Alma MARC data.
 
+## Current Notebooks:
+
+| Notebook Path  | Description 
+|----------------|-------------
+| `tag_export.py` | Notebook to extract full, raw values for a set of MARC tags
+
+
+
 ## Developing 
 
 The recommended approach for developing a Marimo notebook is to use the Marimo GUI editor:
 
+Because this notebook repository will contain multiple notebooks, it's recommended to launch them like this:
+
 ```shell
-make edit-notebook
+uv run marimo edit --sandbox --headless --no-token <notebook_path>
+```
+
+Or, in some cases a developer has kindly created a Makefile command, e.g.:
+
+```shell
+make edit-notebook-tag-export
 ```
 
 ### Dependencies
@@ -44,7 +60,7 @@ make lint
 Often, notebooks are [served as an "app"](https://docs.marimo.io/guides/apps/).  This is the default mode for [marimo-launcher](https://github.com/MITLibraries/marimo-launcher).
 
 ```shell
-uv run marimo run --sandbox --headless --no-token notebook.py
+uv run marimo run --sandbox --headless --no-token <notebook_path>
 ```
 
 ## Environment Variables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,10 +97,15 @@ fixture-parentheses = false
     "ANN201",
     "ANN202",
     "E501",
+    "E722",
+    "FBT003",
+    "N803",
     "PLC0415",
     "PLR1711",
     "PLR2004",
     "S101",
+    "S608",
+    "T201"
 ]
 
 [tool.ruff.lint.pycodestyle]
@@ -108,3 +113,6 @@ max-doc-length = 90
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.marimo.runtime]
+dotenv = [".env"]

--- a/tag_export.py
+++ b/tag_export.py
@@ -1,7 +1,22 @@
+# /// script
+# requires-python = ">=3.13"
+#
+# dependencies = [
+#   "dotenv",
+#   "lxml==5.4.0",
+#   "marcalyx==1.0.2",
+#   "marimo",
+#   "pandas==2.3.0",
+#   "timdex-dataset-api",
+# ]
+# [tool.uv.sources]
+# timdex-dataset-api = { git = "https://github.com/MITLibraries/timdex-dataset-api", editable=true } # noqa: W505
+# ///
+
 import marimo
 
 __generated_with = "0.15.0"
-app = marimo.App(width="medium")
+app = marimo.App(width="full", app_title="MARC tag values")
 
 
 @app.cell
@@ -11,15 +26,284 @@ def _():
     return (mo,)
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo):
     mo.md(
-        """
+        r"""
     # Alma MARC tag values
 
     This notebook provides a way to extract tags from MARC records using versions stored in the TIMDEX dataset.
     """
     )
+    return
+
+
+@app.cell
+def _(mo):
+    # instantiate TIMDEXDataset instance and setup logging
+    with mo.status.spinner(title="Loading application..."):
+        import os
+
+        from timdex_dataset_api import TIMDEXDataset
+        from timdex_dataset_api.config import configure_dev_logger
+
+        configure_dev_logger()
+
+        timdex_dataset = TIMDEXDataset(os.environ["TIMDEX_DATASET_LOCATION"])
+
+    return TIMDEXDataset, timdex_dataset
+
+
+@app.cell
+def _(TIMDEXDataset):
+    import time
+    from collections.abc import Iterator
+
+    import marcalyx
+    import pandas as pd
+    from lxml import etree
+
+    class AlmaTagAnalysis:
+        def __init__(self, timdex_dataset: TIMDEXDataset):
+            self.timdex_dataset = timdex_dataset
+
+        def parse_tags_from_record(
+            self, record: dict, tags: list[str]
+        ) -> Iterator[tuple[str, str, str]]:
+            """Load MARC XML and yield requested tags."""
+            record_xml = etree.fromstring(record["source_record"])
+            record_marc = marcalyx.Record(record_xml)
+
+            for tag in tags:
+                for field in record_marc.field(tag):
+                    yield (
+                        record["timdex_record_id"],
+                        record["run_date"].strftime("%Y-%m-%d"),
+                        str(field),
+                    )
+
+        def run(
+            self,
+            tags: list[str],
+            timdex_record_id_regex_input: str,
+            limit: int | None = None,
+        ) -> pd.DataFrame:
+            """Prepare a DataFrame of timdex_record_id, tag, tag value."""
+            start_time = time.perf_counter()
+
+            # construct WHERE clause with timdex_record_id regex
+            where = None
+            if timdex_record_id_regex_input != "":
+                where = (
+                    f"""timdex_record_id similar to '{timdex_record_id_regex_input}'"""
+                )
+
+            # retrieve record dicts and prepare a list of (record,tag,tag_value) tuples
+            rows = []
+            for record_dict in self.timdex_dataset.read_dicts_iter(  # type: ignore[attr-defined]
+                table="current_records",
+                columns=[
+                    "timdex_record_id",
+                    "run_date",
+                    "source_record",
+                ],
+                source="alma",
+                action="index",
+                where=where,
+                limit=limit,
+            ):
+                rows.extend(list(self.parse_tags_from_record(record_dict, tags)))
+
+            # construct a final dataframe
+            df = pd.DataFrame(
+                rows, columns=["timdex_record_id", "last_modified", "tag_data"]
+            )
+            print(f"elapsed: {time.perf_counter() - start_time}")
+            return df
+
+    return AlmaTagAnalysis, etree, marcalyx, time
+
+
+@app.cell
+def _(mo):
+    tags_input = mo.ui.text(
+        value="245", label="MARC tags (comma-separated)", full_width=True
+    )
+
+    timdex_record_id_regex_input = mo.ui.text(
+        value="alma:.*", label="TIMDEX Record ID Regex", full_width=True
+    )
+
+    limit_input = mo.ui.text(value="50", label="Record limit", full_width=True)
+
+    run_button = mo.ui.run_button(label="Run Analysis")
+
+    mo.vstack(
+        [
+            mo.md("### Analysis Configuration"),
+            tags_input,
+            timdex_record_id_regex_input,
+            limit_input,
+            run_button,
+        ]
+    )
+    return limit_input, run_button, tags_input, timdex_record_id_regex_input
+
+
+@app.cell
+def _():
+    # init results dict with defaults
+    results = {"first_run": True, "table": None, "elapsed": 0}
+    return (results,)
+
+
+@app.cell
+def _(
+    AlmaTagAnalysis,
+    limit_input,
+    mo,
+    results,
+    run_button,
+    tags_input,
+    timdex_dataset,
+    timdex_record_id_regex_input,
+    time,
+):
+    if results["first_run"] or run_button.value:
+        with mo.status.spinner(title="Querying TIMDEX Dataset..."):
+            start_time = time.perf_counter()
+
+            # parse limit
+            try:
+                limit = int(limit_input.value.strip())
+            except:
+                limit = limit_input.value.strip().lower()
+                if limit == "none":
+                    limit = None
+
+            # parse id regex
+            timdex_record_id_regex_value = timdex_record_id_regex_input.value.strip()
+
+            # parse tags
+            tags = [tag.strip() for tag in tags_input.value.split(",") if tag.strip()]
+
+            # main work
+            ata = AlmaTagAnalysis(timdex_dataset)
+            df = ata.run(
+                tags=tags,
+                timdex_record_id_regex_input=timdex_record_id_regex_value,
+                limit=limit,
+            )
+            elapsed_time = time.perf_counter() - start_time
+
+            # prepare results
+            results["df"] = df
+            results["elapsed"] = elapsed_time
+            results["first_run"] = False
+
+    results_table = mo.ui.table(results["df"], selection="single")
+    mo.vstack(
+        [
+            mo.md("### Results"),
+            mo.md(f"**Runtime: {results['elapsed']:.2f} seconds**"),
+            results_table,
+        ]
+    )
+    return (results_table,)
+
+
+@app.cell
+def _(mo, results_table, timdex_dataset):
+    if len(results_table.value) == 0:
+        mo.stop(True, mo.md("To view record details, please select a record from above."))
+
+    result_row = results_table.value.iloc[0]
+    timdex_record_id = result_row.timdex_record_id
+
+    with mo.status.spinner(title="Retrieving record version from TIMDEX..."):
+        metadata_result_df = timdex_dataset.metadata.conn.query(
+            f"""
+            select
+                timdex_record_id,
+                run_timestamp,
+                run_type,
+                run_id,
+                action,
+                run_record_offset
+            from metadata.records
+            where timdex_record_id = '{timdex_record_id}'
+            order by run_timestamp
+            ;
+            """
+        ).to_df()
+
+    record_versions_table = mo.ui.table(metadata_result_df, selection="single")
+    record_versions_table  # noqa: B018
+    return (record_versions_table,)
+
+
+@app.cell(hide_code=True)
+def _(mo, record_versions_table, timdex_dataset):
+    if len(record_versions_table.value) == 0:
+        mo.stop(True, mo.md("Lastly, please select a record version from above."))
+
+    selected_version = record_versions_table.value.iloc[0]
+
+    with mo.status.spinner(title="Retrieving record..."):
+        version = next(
+            timdex_dataset.read_dicts_iter(
+                timdex_record_id=selected_version.timdex_record_id,
+                run_id=selected_version.run_id,
+                run_record_offset=selected_version.run_record_offset,
+            )
+        )
+    return (version,)
+
+
+@app.cell
+def _(etree, marcalyx, mo, record_versions_table, version):
+
+    if len(record_versions_table.value) == 0:
+        mo.stop(True, mo.md("Will show record upon version selection."))
+
+    # get MARC XML and prettify
+    source_record = version["source_record"]
+    root = etree.fromstring(source_record)
+    source_record_pretty = etree.tostring(root, pretty_print=True, encoding="unicode")
+
+    # load MARC XML and produce string version
+    record_marc = marcalyx.Record(root)
+    marc_pretty = "\n".join([str(field) for field in record_marc.fields])
+
+    mo.md(
+        f"""
+    # Record Details
+
+    - TIMDEX Record ID: `{version["timdex_record_id"]}`
+    - Run ID: `{version["run_id"]}`
+    - Run Timestamp: `{version["run_timestamp"]}`
+    - 245 Tag: `{record_marc.titleStatement()}"
+    - [Alma Link](https://mit.primo.exlibrisgroup.com/permalink/01MIT_INST/1np2a75/{version["timdex_record_id"].replace(":", "")})
+
+    ## MARC
+
+    ```text
+    {marc_pretty}
+    ```
+
+    ## MARC XML
+
+    ```xml
+    {source_record_pretty}
+    ```
+
+    """
+    )
+    return
+
+
+@app.cell
+def _():
     return
 
 


### PR DESCRIPTION
### Purpose and background context

This PR turns the stubbed `tag_export.py` notebook into a functional notebook.  This is 90% a port from the [POC notebook in `timdex-notebooks`](https://github.com/MITLibraries/timdex-notebooks/blob/main/marimo_notebooks/marc_tag_values.py) and 10% improvement on that.  This first pass is establishing a baseline similar to the POC to continue testing in a deployed context.

There are currently no meaningful tests.  I'm feeling a little uncertain what kind of tests would be valuable for such a notebook, and would like to return to that in a future PR.  Having this notebook functional will unblock us to test the notebook in a deployed fashion: configurations, permissions, memory/CPU resources tuning, etc.

### How can a reviewer manually see the effects of these changes?

With those caveats above, it _is_ functional as-is!

1- Set Dev1 AWS `TimdexManagers` credentials in terminal and set env vars:
```shell
TDA_LOG_LEVEL=DEBUG
WARNING_ONLY_LOGGERS=asyncio,botocore,urllib3,s3transfer,boto3,MARKDOWN
TIMDEX_DATASET_LOCATION=s3://timdex-extract-dev-222053980223/dataset_scratch/prod-clone
```

2- Start notebook with Makefile, that opens it in edit mode:
```shell
make edit-notebook-tag-export
```

3- View as "app" mode which is consistent with how users will see it.  Click this button in the lower-right:

<img width="150" height="299" alt="Screenshot 2025-08-26 at 1 18 10 PM" src="https://github.com/user-attachments/assets/9300dc74-0858-4a25-9136-f57c5c1df006" />

4- Experiment with MARC tags (e.g. try `650,655` or `918,985,900`), and limits, etc!   Just  be aware that omitting the limit, or setting it large, can take quite awhile.  I think the full Alma "current records" is about 3.9m, and takes about 10 minutes to download and parse tags.

As I type this... realizing we may have an opportunity for caching records we've downloaded; maybe For a future ticket 😎.

5- Perform an export.  Try a small set like:

<img width="333" height="360" alt="Screenshot 2025-08-26 at 1 21 50 PM" src="https://github.com/user-attachments/assets/cfc480cf-51d5-48ee-b53a-18d71040ac07" />

Then try to export it using the "Download" UI in the lower-right:

<img width="426" height="251" alt="Screenshot 2025-08-26 at 1 22 32 PM" src="https://github.com/user-attachments/assets/25e58637-7868-4402-81de-ec727443b7bb" />

### Includes new or updated dependencies?
YES

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1438

